### PR TITLE
fix(packer_fmt): updates packer_fmt hook to format files that fail the check

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ projects using [Packer](https://www.packer.io/).
 
 ## Available Hooks ##
 
-| Hook name         | Description                                             |
-| ----------------- | ------------------------------------------------------- |
-| `packer_validate` | Validate all Packer templates.                          |
-| `packer_fmt`      | Check that Packer HCL templates are properly formatted. |
+| Hook name         | Description                                                                           |
+| ----------------- |---------------------------------------------------------------------------------------|
+| `packer_validate` | Validate all Packer templates.                                                        |
+| `packer_fmt`      | Check that Packer HCL templates are properly formatted, formatting files when needed. |
 
 ## Usage ##
 

--- a/hooks/packer_fmt.sh
+++ b/hooks/packer_fmt.sh
@@ -13,6 +13,7 @@ error=0
 
 for file in "$@"; do
   if ! packer fmt -check "$file"; then
+    packer fmt -write "$file"
     error=1
     echo
     echo "Failed path: $file"


### PR DESCRIPTION
## 🗣 Description ##

This updates the `packer_fmt` hook so that it will format the file that failed its check. This allows a user to simply add the modified file and proceed with their commit.

## 💭 Motivation and context ##

This improves the developer experience, allowing them to simply add the formatted file and continue their commit.

## 🧪 Testing ##

Tested by modifying a packer hcl file and letting the hook reformat the file and fail the check.

## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - _eschew scope creep!_
- [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments. -- no TODOs added
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] All new and existing tests pass.
