### PR TITLE
Adding capability for packer_fmt to interpret options

### DIFF
--- a/hooks/packer_fmt.sh
+++ b/hooks/packer_fmt.sh
@@ -11,8 +11,31 @@ fi
 
 error=0
 
-for file in "$@"; do
-  if ! packer fmt -check "$file"; then
+options=""
+files=()
+packer_cmd=""
+for arg in "$@"; do
+  # Filtering out packer options from packer files
+  # based on if they start with a "-" or not.
+  # We are assuming that files will not begin with a "-".
+  if [[ $arg == -* ]]; then
+    options+="$arg "
+  else
+    files+=("$arg")
+  fi
+done
+
+# Remove the trailing space
+options="${options%' '}"
+
+if [[ -z $options ]]; then
+  packer_cmd="packer fmt -check"
+else
+  packer_cmd="packer fmt $options"
+fi
+
+for file in "${files[@]}"; do
+  if ! $packer_cmd "$file"; then
     error=1
     echo
     echo "Failed path: $file"


### PR DESCRIPTION
Adding capability for packer_fmt.sh handle packer command options
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
The packer_fmt.sh script could not handle packer options such as `-write=true`, `-recursive` etc. as it was interpreting them as files instead of being options given to the packer command.

This change filters out the packer options from the files by checking if the argument starts with a hyphen (-). If it starts with a hyphen it is a packer option otherwise it is a file.

Of course, if a filename starts with a hyphen it will be treated as an option and it is on the user's shoulders to name the file correctly to work with this hook.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
The code was tested with a sample test file test.pkr.hcl likes this:
```yaml
packer {
  required_plugins {
    amazon = {
      version = "~> 1.0"
      source  = "github.com/hashicorp/amazon"
    }
  }
}
```

Changes were made manually to this file for various cases and the following commands were tested:
.`/packer_fmt.sh test.pkr.hcl`
`./packer_fmt.sh -write=true test.pkr.hcl`
`./packer_fmt.sh -write=true -recursive test.pkr.hcl`
`./packer_fmt.sh -write=true -recursive -check test.pkr.hcl`
`./packer_fmt.sh -write=true -diff test.pkr.hcl`
`./packer_fmt.sh -write=true -stuff test.pkr.hcl`

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
