### PR TITLE
Adjust files supported by the hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,7 +6,6 @@
   language: script
   files: \.pkr\.hcl$
   pass_filenames: true
-  always_run: true
 
 - id: packer_fmt
   name: Packer Format

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   description: This hook runs `packer validate` on appropriate files.
   entry: hooks/packer_validate.sh
   language: script
-  files: (packer\.json|\.pkr\.hcl)$
+  files: \.pkr\.hcl$
   pass_filenames: true
   always_run: true
 
@@ -13,5 +13,5 @@
   description: This hook runs `packer fmt` on appropriate files.
   entry: hooks/packer_fmt.sh
   language: script
-  files: (\.pkr\.hcl)$
+  files: \.pkr(?:vars)?\.hcl$
   pass_filenames: true

--- a/README.md
+++ b/README.md
@@ -20,15 +20,8 @@ repos:
     rev: v0.0.2
     hooks:
       - id: packer_validate
-        args:
-          - manual_file_entry
       - id: packer_fmt
 ```
-
-## Notes about the `packer_validate` hook ##
-
-This hook matches any paths ending in `packer.json` and `.pkr.hcl` by default.
-File paths can be added for checking manually as additional arguments.
 
 ## Contributing ##
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adjusts the files supported by the hooks defined in this repository.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

At this point there is no sense in continuing to support `packer.json` files as the HCL2 configuration language has been preferred since Packer 1.7. We should also be formatting any `.pkrvars.hcl` files just like we would otherwise format `.tfvars` files in a Terraform configuration.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that the expected files are picked up with these patterns.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
