### PR TITLE
Pass arguments to Packer

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -11,6 +11,8 @@
   name: Packer Format
   description: This hook runs `packer fmt` on appropriate files.
   entry: hooks/packer_fmt.sh
+  args:
+    - -check
   language: script
   files: \.pkr(?:vars)?\.hcl$
   pass_filenames: true

--- a/hooks/packer_fmt.sh
+++ b/hooks/packer_fmt.sh
@@ -9,10 +9,26 @@ if [ -z "$(command -v packer)" ]; then
   exit 1
 fi
 
+args=()
+files=()
+
+while (("$#")); do
+  case "$1" in
+    -*)
+      args+=("$1")
+      shift
+      ;;
+    *)
+      files+=("$1")
+      shift
+      ;;
+  esac
+done
+
 error=0
 
-for file in "$@"; do
-  if ! packer fmt -check "$file"; then
+for file in "${files[@]}"; do
+  if ! packer fmt "${args[@]}" "$file"; then
     error=1
     echo
     echo "Failed path: $file"

--- a/hooks/packer_validate.sh
+++ b/hooks/packer_validate.sh
@@ -9,10 +9,26 @@ if [ -z "$(command -v packer)" ]; then
   exit 1
 fi
 
+args=()
+files=()
+
+while (("$#")); do
+  case "$1" in
+    -*)
+      args+=("$1")
+      shift
+      ;;
+    *)
+      files+=("$1")
+      shift
+      ;;
+  esac
+done
+
 error=0
 
-for file in "$@"; do
-  if ! packer validate "$file"; then
+for file in "${files[@]}"; do
+  if ! packer validate "${args[@]}" "$file"; then
     error=1
     echo
     echo "Failed path: $file"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds naive argument pass-through for the `packer_fmt` and `packer_validate` hooks.

> [!WARNING]
> This naive approach will not differentiate file paths that begin with a `-` from arguments. However, when testing a workaround I found that _a lot_ of hooks also do not like paths that begin with a `-`.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This will allow consumers of the hook to pass options through to the underlying Packer calls. It will also allow one to override the current default behavior of the `packer_fmt` hook to only check and not write changes to files. Note that this effectively replaces #13 and #25 by allowing a consumer of the hook to set their own arguments.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. This worked as expected when I tested it locally.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
