### PR TITLE
Use directories instead of individual files for the `packer_validate` hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,6 +6,7 @@
   language: script
   files: \.pkr\.hcl$
   pass_filenames: true
+  require_serial: true
 
 - id: packer_fmt
   name: Packer Format

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,8 +5,6 @@
   entry: hooks/packer_validate.sh
   language: script
   files: \.pkr\.hcl$
-  pass_filenames: true
-  require_serial: true
 
 - id: packer_fmt
   name: Packer Format
@@ -16,4 +14,3 @@
     - -check
   language: script
   files: \.pkr(?:vars)?\.hcl$
-  pass_filenames: true

--- a/hooks/packer_validate.sh
+++ b/hooks/packer_validate.sh
@@ -25,13 +25,23 @@ while (("$#")); do
   esac
 done
 
+paths=()
+index=0
+for file in "${files[@]}"; do
+  paths[index]=$(dirname "$file")
+  ((++index))
+done
+
+unique_paths=()
+while IFS='' read -r line; do unique_paths+=("$line"); done < <(printf '%s\n' "${paths[@]}" | sort --unique)
+
 error=0
 
-for file in "${files[@]}"; do
-  if ! packer validate "${args[@]}" "$file"; then
+for path in "${unique_paths[@]}"; do
+  if ! packer validate "${args[@]}" "$path"; then
     error=1
     echo
-    echo "Failed path: $file"
+    echo "Failed path: $path"
     echo "================================"
   fi
 done


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the `packer_validate` hook to process unique directories instead of individual files. It also removes the `pass_filenames` option from the hook configurations for both the `packer_fmt` and the `packer_validate` hooks.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This change will allow us to support multiple `*.pkr.hcl` files for a configuration instead of having to cram everything into a single file to ensure it passes the `packer_validate` hook. This change is also necessary to support converting the Packer configurations in [cisagov/cyhy_amis] to use HCL2 instead of the legacy JSON format.

The `pass_filesnames` option is removed from both hooks because it is setting the option to the default value.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I tested this version of the hook against [cisagov/skeleton-packer] after decomposing the `packer.pkr.hcl` file.

> [!NOTE]
> The local versions run below have some debug output present just for verification.

```console
$ ls -l src/*.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj  593 Sep 10 17:56 src/amis.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj 3779 Sep 10 17:57 src/build.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj   65 Sep 10 17:56 src/locals.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj  402 Sep 10 17:57 src/packer.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj 1467 Sep 10 17:56 src/variables.pkr.hcl

$ pre-commit run packer_fmt_local --all-files
Test the local version of packer_fmt.....................................Passed
- hook id: packer_fmt_local
- duration: 5.28s

Arguments: -check
Files: src/build.pkr.hcl src/amis.pkr.hcl src/locals.pkr.hcl src/packer.pkr.hcl
Arguments: -check
Files: src/variables.pkr.hcl

$ pre-commit run packer_validate_local --all-files
Test the local version of packer_validate................................Passed
- hook id: packer_validate_local
- duration: 4.9s

Arguments:
Files: src/build.pkr.hcl src/amis.pkr.hcl src/locals.pkr.hcl src/packer.pkr.hcl
Paths: src src src src
Unique paths: src
The configuration is valid.
Arguments:
Files: src/variables.pkr.hcl
Paths: src
Unique paths: src
The configuration is valid.
```

I also converted the Packer configurations in [cisagov/cyhy_amis] to HCL2 and used the local versions to verify the configuration:

```console
$ ls -l packer/*.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj  519 Sep 10 15:35 packer/base_images.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj 1579 Sep 10 15:47 packer/bastion.json.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj 1592 Sep 10 15:47 packer/dashboard.json.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj 1596 Sep 10 15:47 packer/docker.json.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj   65 Sep 10 15:34 packer/locals.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj 1611 Sep 10 15:47 packer/mongo.json.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj 1573 Sep 10 15:47 packer/nessus.json.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj 1561 Sep 10 15:47 packer/nmap.json.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj  218 Sep 10 15:34 packer/packer.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj 1589 Sep 10 15:47 packer/reporter.json.pkr.hcl
-rw-r--r-- 1 mcdonnnj mcdonnnj  260 Sep 10 15:40 packer/variables.pkr.hcl

$ pre-commit run packer_fmt_local --all-files
Test the local version of packer_fmt.....................................Passed
- hook id: packer_fmt_local
- duration: 5.32s

Arguments: -write=true
Files: packer/locals.pkr.hcl packer/base_images.pkr.hcl packer/nessus.json.pkr.hcl packer/bastion.json.pkr.hcl
Arguments: -write=true
Files: packer/packer.pkr.hcl packer/variables.pkr.hcl packer/dashboard.json.pkr.hcl packer/mongo.json.pkr.hcl
Arguments: -write=true
Files: packer/docker.json.pkr.hcl packer/nmap.json.pkr.hcl packer/reporter.json.pkr.hcl

$ pre-commit run packer_validate_local --all-files
Test the local version of packer_validate................................Passed
- hook id: packer_validate_local
- duration: 11.75s

Arguments:
Files: packer/base_images.pkr.hcl packer/bastion.json.pkr.hcl packer/dashboard.json.pkr.hcl packer/docker.json.pkr.hcl packer/locals.pkr.hcl packer/mongo.json.pkr.hcl packer/nessus.json.pkr.hcl packer/nmap.json.pkr.hcl packer/packer.pkr.hcl packer/reporter.json.pkr.hcl packer/variables.pkr.hcl
Paths: packer packer packer packer packer packer packer packer packer packer packer
Unique paths: packer
The configuration is valid.
```

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

[cisagov/cyhy_amis]: https://github.com/cisagov/cyhy_amis
[cisagov/skeleton-packer]: https://github.com/cisagov/skeleton-packer
