### PR TITLE
Support file paths with a leading `-`

### DIFF
--- a/hooks/packer_fmt.sh
+++ b/hooks/packer_fmt.sh
@@ -15,7 +15,11 @@ files=()
 while (("$#")); do
   case "$1" in
     -*)
-      args+=("$1")
+      if [ -f "$1" ]; then
+        files+=("$1")
+      else
+        args+=("$1")
+      fi
       shift
       ;;
     *)
@@ -28,7 +32,7 @@ done
 error=0
 
 for file in "${files[@]}"; do
-  if ! packer fmt "${args[@]}" "$file"; then
+  if ! packer fmt "${args[@]}" -- "$file"; then
     error=1
     echo
     echo "Failed path: $file"

--- a/hooks/packer_validate.sh
+++ b/hooks/packer_validate.sh
@@ -15,7 +15,11 @@ files=()
 while (("$#")); do
   case "$1" in
     -*)
-      args+=("$1")
+      if [ -f "$1" ]; then
+        files+=("$1")
+      else
+        args+=("$1")
+      fi
       shift
       ;;
     *)
@@ -28,7 +32,7 @@ done
 paths=()
 index=0
 for file in "${files[@]}"; do
-  paths[index]=$(dirname "$file")
+  paths[index]=$(dirname -- "$file")
   ((++index))
 done
 
@@ -38,7 +42,7 @@ while IFS='' read -r line; do unique_paths+=("$line"); done < <(printf '%s\n' "$
 error=0
 
 for path in "${unique_paths[@]}"; do
-  if ! packer validate "${args[@]}" "$path"; then
+  if ! packer validate "${args[@]}" -- "$path"; then
     error=1
     echo
     echo "Failed path: $path"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request makes changes to support file paths with leading `-` characters.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

In #37 we added support to pass arguments through to the underlying Packer call. However, the naive implementation meant that if a file path began with a leading `-` it was treated as an argument and not a file.

> [!NOTE]
> This introduces a different limitation whereby if a file with the same name as an argument exists, then the argument will not be treated as such. This is incredibly edge case and unlikely to be an issue, but I wanted to document it nonetheless.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that the hooks would work as expected when a file with a leading `-` was present.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
