### PR TITLE
Fix overly match-happy sed commands

### DIFF
--- a/bump-version
+++ b/bump-version
@@ -25,6 +25,9 @@ END_OF_LINE
 )
 
 old_version=$(< "$VERSION_FILE")
+# Comment out periods so they are interpreted as periods and don't
+# just match any character
+old_version_regex=${old_version//\./\\\.}
 new_version="$old_version"
 
 bump_part=""
@@ -143,9 +146,9 @@ if [ "$with_prerelease" = true ]; then
 fi
 
 tmp_file=/tmp/version.$$
-sed "s/$old_version/$new_version/" $VERSION_FILE > $tmp_file
+sed "s/$old_version_regex/$new_version/" $VERSION_FILE > $tmp_file
 mv $tmp_file $VERSION_FILE
-sed "s/$old_version/$new_version/" $README_FILE > $tmp_file
+sed "s/$old_version_regex/$new_version/" $README_FILE > $tmp_file
 mv $tmp_file $README_FILE
 git add $VERSION_FILE $README_FILE
 git commit --message "$commit_prefix version from $old_version to $new_version"


### PR DESCRIPTION
## 🗣 Description ##

This pull request tightens a couple of `sed` commands so that their regexps do not inadvertently match when they should not. 

## 💭 Motivation and context ##

We made similar changes in https://github.com/cisagov/skeleton-python-library/pull/104 and they should be made here as well.

## 🧪 Testing ##

I tested locally and verified that with these changes the script behave as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.