### PR TITLE
Add a new option to the `bump-version` script to list files it updates

### DIFF
--- a/bump-version
+++ b/bump-version
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # bump-version [--push] [--label LABEL] (major | minor | patch | prerelease | build | finalize | show)
+# bump-version --list-files
 
 set -o nounset
 set -o errexit
@@ -17,12 +18,14 @@ Update the version of the project.
 
 Usage:
   ${0##*/} [--push] [--label LABEL] (major | minor | patch | prerelease | build | finalize | show)
+  ${0##*/} --list-files
   ${0##*/} (-h | --help)
 
 Options:
   -h | --help    Show this message.
   --push         Perform a \`git push\` after updating the version.
   --label LABEL  Specify the label to use when updating the build or prerelease version.
+  --list-files   List the files that will be updated when the version is bumped.
 END_OF_LINE
 )
 
@@ -105,6 +108,10 @@ else
         ;;
       -h | --help)
         echo "$USAGE"
+        exit 0
+        ;;
+      --list-files)
+        printf '%s\n' "${VERSION_FILES[@]}"
         exit 0
         ;;
       *)

--- a/bump-version
+++ b/bump-version
@@ -6,8 +6,10 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+# Stores the canonical version for the project.
 VERSION_FILE=config/version.txt
-README_FILE=README.md
+# Files that should be updated with the new version.
+VERSION_FILES=("$VERSION_FILE" README.md)
 
 USAGE=$(
   cat << END_OF_LINE
@@ -146,11 +148,16 @@ if [ "$with_prerelease" = true ]; then
 fi
 
 tmp_file=/tmp/version.$$
-sed "s/$old_version_regex/$new_version/" $VERSION_FILE > $tmp_file
-mv $tmp_file $VERSION_FILE
-sed "s/$old_version_regex/$new_version/" $README_FILE > $tmp_file
-mv $tmp_file $README_FILE
-git add $VERSION_FILE $README_FILE
+for version_file in "${VERSION_FILES[@]}"; do
+  if [ ! -f "$version_file" ]; then
+    echo Missing expected file: "$version_file"
+    exit 1
+  fi
+  sed "s/$old_version_regex/$new_version/" "$version_file" > $tmp_file
+  mv $tmp_file "$version_file"
+done
+
+git add "${VERSION_FILES[@]}"
 git commit --message "$commit_prefix version from $old_version to $new_version"
 
 if [ "$with_push" = true ]; then


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a `--list-files` option to list out any files the `bump-version` script updates when changing versions. This is in addition to updating the script to store any files it updates in an array.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The array itself is a good improvement, but the new option is in support of https://github.com/cisagov/gh-skeleton/issues/31.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified the new option works as expected:

```console
$ ./bump-version --list-files
config/version.txt
README.md
```
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
