### PR TITLE
feat: allow disabling pushd with `--no-cd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ repos:
     hooks:
       - id: packer_fmt
       - id: packer_validate
+        args: [--no-cd] # Optionally disable changing working directory
 ```
 
 ## Contributing ##

--- a/hooks/packer_validate.sh
+++ b/hooks/packer_validate.sh
@@ -7,11 +7,11 @@ set -o pipefail
 function packer_validate() {
   local exit_code=0
 
-  packer init . > /dev/null
+  packer init "$1" > /dev/null
 
   # Allow us to get output if the validation fails
   set +o errexit
-  validate_output=$(packer validate "${ARGS[@]}" . 2>&1)
+  validate_output=$(packer validate "${ARGS[@]}" "$1" 2>&1)
   exit_code=$?
   set -o errexit
 
@@ -42,8 +42,12 @@ pids=()
 for path in "${UNIQUE_PATHS[@]}"; do
   # Check each path in parallel
   {
-    pushd "$path" > /dev/null
-    packer_validate
+    if [[ $NO_CD -eq 1 ]]; then
+      packer_validate "$path"
+    else
+      pushd "$path" > /dev/null
+      packer_validate .
+    fi
   } &
   pids+=("$!")
 done

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -9,14 +9,20 @@ set -o pipefail
 # Globals:
 #   ARGS
 #   FILES
+#   NO_CD
 #######################################
 function util::parse_cmdline() {
   # Global variable arrays
   ARGS=()
   FILES=()
+  export NO_CD=0
 
   while (("$#")); do
     case "$1" in
+      --no-cd)
+        NO_CD=1
+        shift
+        ;;
       -*)
         if [ -f "$1" ]; then
           FILES+=("$1")


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->
This PR allows to alter `packer_validate` behavior to not change working directory when `--no-cd` is passed as an argument, like it was before https://github.com/cisagov/pre-commit-packer/pull/47.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->
Closes #51 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested locally with and without passing `--no-cd` as args, e.g.:
```
repos:
  - repo: https://github.com/pdecat/pre-commit-packer
    rev: feat/optional-cd
    hooks:
      - id: packer_validate
        args: [--no-cd] # disable changing working directory
      - id: packer_fmt
```

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
