### PR TITLE
Run hooks in parallel on each path

### DIFF
--- a/hooks/packer_fmt.sh
+++ b/hooks/packer_fmt.sh
@@ -22,9 +22,6 @@ error=0
 for file in "${FILES[@]}"; do
   if ! packer fmt "${ARGS[@]}" -- "$file"; then
     error=1
-    echo
-    echo "Failed path: $file"
-    echo "================================"
   fi
 done
 

--- a/hooks/packer_fmt.sh
+++ b/hooks/packer_fmt.sh
@@ -17,10 +17,20 @@ source "$SCRIPT_DIR/../lib/util.sh"
 
 util::parse_cmdline "$@"
 
-error=0
-
+pids=()
 for file in "${FILES[@]}"; do
-  if ! packer fmt "${ARGS[@]}" -- "$file"; then
+  # Check each path in parallel
+  {
+    packer fmt "${ARGS[@]}" -- "$file"
+  } &
+  pids+=("$!")
+done
+
+error=0
+exit_code=0
+for pid in "${pids[@]}"; do
+  wait "$pid" || exit_code=$?
+  if [[ $exit_code -ne 0 ]]; then
     error=1
   fi
 done

--- a/hooks/packer_validate.sh
+++ b/hooks/packer_validate.sh
@@ -27,9 +27,6 @@ for path in "${UNIQUE_PATHS[@]}"; do
   packer init . > /dev/null
   if ! packer validate "${ARGS[@]}" .; then
     error=1
-    echo
-    echo "Failed path: $path"
-    echo "================================"
   fi
 done
 

--- a/hooks/packer_validate.sh
+++ b/hooks/packer_validate.sh
@@ -4,6 +4,25 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+function packer_validate() {
+  local exit_code=0
+
+  packer init . > /dev/null
+
+  # Allow us to get output if the validation fails
+  set +o errexit
+  validate_output=$(packer validate "${ARGS[@]}" . 2>&1)
+  exit_code=$?
+  set -o errexit
+
+  if [[ $exit_code -ne 0 ]]; then
+    echo "Validation failed in $path"
+    echo -e "$validate_output\n\n"
+  fi
+
+  return $exit_code
+}
+
 if [ -z "$(command -v packer)" ]; then
   echo "packer is required"
   exit 1
@@ -24,8 +43,7 @@ for path in "${UNIQUE_PATHS[@]}"; do
   # Check each path in parallel
   {
     pushd "$path" > /dev/null
-    packer init . > /dev/null
-    packer validate "${ARGS[@]}" .
+    packer_validate
   } &
   pids+=("$!")
 done


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request changes both the `packer_fmt` and `packer_validate` hooks to run against each provided path in parallel using command blocks and the `&` operator. It also removes the custom output for the `packer_fmt` hook because `packer fmt` does not return a non-zero exit code if it formats files. The output for the `packer_validate` hook is updated to correctly work for each path that is provided.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This will help performance in more complex scenarios such as monorepos with a number of templates and/or files in a template. It also fixes the `packer_validate` hook to correctly provide output for every path it is run against if any one or more of those paths were to fail validation. Incidentally this obviates the need for #53 because running core hook functionality in command blocks results in a forked process that does not change the current directory of the parent hook process.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I tested this against scenarios that included a single template and multiple templates to ensure expected output and failure cases.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
