### PR TITLE
Run `packer fmt` on directories instead of files

### DIFF
--- a/hooks/packer_fmt.sh
+++ b/hooks/packer_fmt.sh
@@ -17,11 +17,13 @@ source "$SCRIPT_DIR/../lib/util.sh"
 
 util::parse_cmdline "$@"
 
+util::get_unique_directory_paths "${FILES[@]}"
+
 pids=()
-for file in "${FILES[@]}"; do
+for path in "${UNIQUE_PATHS[@]}"; do
   # Check each path in parallel
   {
-    packer fmt "${ARGS[@]}" -- "$file"
+    packer fmt "${ARGS[@]}" -- "$path"
   } &
   pids+=("$!")
 done


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the `packer_fmt` hook to run against unique directory paths instead of individual files.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

So it turns out that when you provide a directory to `packer fmt` it will format any applicable file within that directory. This is, in my opinion, a cleaner approach to leverage instead of running against each individual file.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified this works in a testing template.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
